### PR TITLE
Add list of optional filenames to the check.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ function nowApi () {
       la(is.strings(filenames), 'missing file names', filenames)
       la(is.not.empty(filenames), 'expected list of files', filenames)
 
+      // Files not required, but might be checked for by la
       const optionalFiles = ['.npmignore']
 
       filenames.forEach(name => {

--- a/src/index.js
+++ b/src/index.js
@@ -118,8 +118,13 @@ function nowApi () {
 
       la(is.strings(filenames), 'missing file names', filenames)
       la(is.not.empty(filenames), 'expected list of files', filenames)
+
+      const optionalFiles = ['.npmignore']
+
       filenames.forEach(name => {
-        la(fs.existsSync(name), 'cannot find file', name)
+        if (!(optionalFiles.includes(name))) {
+          la(fs.existsSync(name), 'cannot find file', name)
+        }
       })
 
       const isPackageJson = R.test(/package\.json$/)


### PR DESCRIPTION
Right now the list is hardcoded, I am going to add another PR later to allow this to overridden by parameters if that seems like a good idea, but this should fix the issue we've been having.

Even though this change is extremely simple, it's a little hard to test. here's a bin showing it will function as expected:

http://jsbin.com/buhahasazo/edit?js,console